### PR TITLE
swap Arial to Noto sans #1

### DIFF
--- a/head.html
+++ b/head.html
@@ -4,3 +4,6 @@
 <script src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&display=swap" rel="stylesheet">

--- a/head.html
+++ b/head.html
@@ -4,6 +4,3 @@
 <script src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&display=swap" rel="stylesheet">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -14,7 +14,7 @@
 @font-face {
   font-family: "Roboto fallback";
   size-adjust: 99.529%;
-  src: local("Arial");
+  src: local("Noto Sans");
 }
 
 :root {
@@ -29,12 +29,13 @@
   --cards-text-color-white: #fff;
 
   /* fonts */
-  --body-font-family: "Roboto", "Roboto fallback", noto, sans-serif;
+  --ff-fallback-default: "Noto Sans", sans-serif;
+  --body-font-family: "Roboto", "Roboto fallback", noto, var(--ff-fallback-default);
   --heading-font-family: var(--body-font-family);
   --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
-  --cards-title-font-family: "Roboto", "Roboto fallback", noto, sans-serif;
-  --cards-text-font-family: 'Roboto Condensed', "Roboto", "Roboto fallback", sans-serif;
-  --hero-text-font-family: 'Roboto Condensed', "Roboto", "Roboto fallback", sans-serif;
+  --cards-title-font-family: "Roboto", "Roboto fallback", noto, var(--ff-fallback-default);
+  --cards-text-font-family: 'Roboto Condensed', "Roboto", "Roboto fallback", var(--ff-fallback-default);
+  --hero-text-font-family: 'Roboto Condensed', "Roboto", "Roboto fallback", var(--ff-fallback-default);
 
   /* body sizes */
   --body-font-size-xl: 28px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,13 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* fallback font for Roboto (normal - 400) */
-@font-face {
-  font-family: "Roboto fallback";
-  size-adjust: 99.529%;
-  src: local("Noto Sans");
-}
-
 :root {
   /* colors */
   --link-color: #babbbd;
@@ -29,13 +22,12 @@
   --cards-text-color-white: #fff;
 
   /* fonts */
-  --ff-fallback-default: "Noto Sans", sans-serif;
-  --body-font-family: "Roboto", "Roboto fallback", noto, var(--ff-fallback-default);
+  --body-font-family: "Roboto", noto, sans-serif;
   --heading-font-family: var(--body-font-family);
   --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
-  --cards-title-font-family: "Roboto", "Roboto fallback", noto, var(--ff-fallback-default);
-  --cards-text-font-family: 'Roboto Condensed', "Roboto", "Roboto fallback", var(--ff-fallback-default);
-  --hero-text-font-family: 'Roboto Condensed', "Roboto", "Roboto fallback", var(--ff-fallback-default);
+  --cards-title-font-family: "Roboto", noto, sans-serif;
+  --cards-text-font-family: 'Roboto Condensed', "Roboto", sans-serif;
+  --hero-text-font-family: 'Roboto Condensed', "Roboto", sans-serif;
 
   /* body sizes */
   --body-font-size-xl: 28px;


### PR DESCRIPTION
# Important

No `develop` branch has been founded. This update goes directly to prod.

## Note

following a legal requirement, is needed to swap `Arial` to `Noto Sans` font. But because the current implementation is a fallback font, we decide to remove the custom fallback font to remove the need of loading a fallback's fallback font in case `Roboto` is not loading.

Fix #1

Test URLs:
- Before: https://main--vg-partsasist--volvogroup.aem.page/
- After: https://1-change-arial-to-notosans--vg-partsasist--volvogroup.aem.page/
